### PR TITLE
fix(infra): convert GKE cluster to data source to stop destroy loop

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -58,13 +58,7 @@ jobs:
             "projects/${{ secrets.GCP_PROJECT_ID }}/locations/us-central1/repositories/microservices-demo" \
             || echo "Artifact Registry: ya importado o no existe, continuando..."
 
-          # Importa el cluster GKE si ya existe y no está en el state
-          terraform import \
-            -var="project_id=${{ secrets.GCP_PROJECT_ID }}" \
-            -var="region=us-central1" \
-            google_container_cluster.primary \
-            "projects/${{ secrets.GCP_PROJECT_ID }}/locations/us-central1/clusters/microservices-cluster" \
-            || echo "GKE cluster: ya importado o no existe, continuando..."
+          # El cluster GKE se gestiona como data source (ya existe en GCP)
         env:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
           TF_VAR_region: "us-central1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,19 +39,11 @@ resource "google_artifact_registry_repository" "microservices" {
   depends_on = [google_project_service.artifactregistry]
 }
 
-# Cluster GKE Autopilot
-# lifecycle ignore_changes = all evita que Terraform intente reconciliar
-# atributos que GCP Autopilot configura automáticamente (redes, versiones, etc.)
-resource "google_container_cluster" "primary" {
+# Cluster GKE Autopilot — referenciado como data source porque ya existe.
+# Terraform no gestiona su ciclo de vida (no crea ni destruye).
+data "google_container_cluster" "primary" {
   name     = var.cluster_name
   location = var.region
 
-  enable_autopilot    = true
-  deletion_protection = false
-
   depends_on = [google_project_service.container]
-
-  lifecycle {
-    ignore_changes = all
-  }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,11 @@
 output "cluster_name" {
   description = "Nombre del cluster GKE"
-  value       = google_container_cluster.primary.name
+  value       = data.google_container_cluster.primary.name
 }
 
 output "cluster_location" {
   description = "Región del cluster"
-  value       = google_container_cluster.primary.location
+  value       = data.google_container_cluster.primary.location
 }
 
 output "artifact_registry_url" {
@@ -15,5 +15,5 @@ output "artifact_registry_url" {
 
 output "kubectl_command" {
   description = "Comando para conectar kubectl al cluster"
-  value       = "gcloud container clusters get-credentials ${google_container_cluster.primary.name} --region ${var.region} --project ${var.project_id}"
+  value       = "gcloud container clusters get-credentials ${data.google_container_cluster.primary.name} --region ${var.region} --project ${var.project_id}"
 }


### PR DESCRIPTION
The cluster already exists in GCP and Autopilot auto-configures attributes that differ from a minimal Terraform definition, causing force-replace on every apply. Converting to a data source tells Terraform to only READ the cluster (never create/destroy it). State was also manually cleaned to remove the stale resource entry.