### PR TITLE
fix(cd): increase helm timeout for GKE Autopilot node provisioning

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -62,21 +62,21 @@ jobs:
           helm upgrade --install vote vote/chart \
             --namespace ${{ env.NAMESPACE }} \
             --set image=${{ env.IMAGE_BASE }}/vote:latest \
-            --wait --timeout 3m
+            --wait --timeout 8m
 
       - name: Desplegar worker
         run: |
           helm upgrade --install worker worker/chart \
             --namespace ${{ env.NAMESPACE }} \
             --set image=${{ env.IMAGE_BASE }}/worker:latest \
-            --wait --timeout 3m
+            --wait --timeout 8m
 
       - name: Desplegar result
         run: |
           helm upgrade --install result result/chart \
             --namespace ${{ env.NAMESPACE }} \
             --set image=${{ env.IMAGE_BASE }}/result:latest \
-            --wait --timeout 3m
+            --wait --timeout 8m
 
       - name: Verificar despliegue
         run: |


### PR DESCRIPTION
Autopilot takes longer to schedule pods on first deploy (node provisioning). 3m was insufficient; increased to 8m for service deployments.