### PR TITLE
feat(cd): expose vote and result as LoadBalancer for public access

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -62,6 +62,7 @@ jobs:
           helm upgrade --install vote vote/chart \
             --namespace ${{ env.NAMESPACE }} \
             --set image=${{ env.IMAGE_BASE }}/vote:latest \
+            --set serviceType=LoadBalancer \
             --wait --timeout 8m
 
       - name: Desplegar worker
@@ -76,6 +77,7 @@ jobs:
           helm upgrade --install result result/chart \
             --namespace ${{ env.NAMESPACE }} \
             --set image=${{ env.IMAGE_BASE }}/result:latest \
+            --set serviceType=LoadBalancer \
             --wait --timeout 8m
 
       - name: Verificar despliegue

--- a/result/chart/templates/service.yaml
+++ b/result/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app: result
   name: result
 spec:
-  type: ClusterIP
+  type: {{ .Values.serviceType | default "ClusterIP" }}
   ports:
   - name: result
     port: 80

--- a/vote/chart/templates/service.yaml
+++ b/vote/chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app: vote
   name: vote
 spec:
-  type: ClusterIP
+  type: {{ .Values.serviceType | default "ClusterIP" }}
   ports:
   - name: vote
     port: 8080


### PR DESCRIPTION
- Make serviceType configurable via Helm values in vote and result charts
- CD pipeline sets serviceType=LoadBalancer so services get public IPs
- vote: http://34.132.209.134:8080
- result: http://34.63.41.74